### PR TITLE
Pin maap-py<5 in remaining environments

### DIFF
--- a/.maap/localized-pipeline/environment.yml
+++ b/.maap/localized-pipeline/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - geoserver-rest==2.9.1
   - geopandas>=0.12.0
   - pip:
-    - maap-py
+    - "maap-py<5"

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - geoserver-rest==2.9.1
   - geopandas>=0.12.0
   - pip:
-    - maap-py
+    - "maap-py<5"


### PR DESCRIPTION
## Summary
- Pin `maap-py<5` in root `environment.yml` and `.maap/localized-pipeline/environment.yml`, matching the pin already present in `.maap/catalog-job/environment.yml`.
- Confirmed the catalog job's `submitJob` version is already `v0.1.9` (set in a prior commit), so no further change was needed there.

## Test plan
- [ ] `conda env update -f environment.yml` resolves cleanly with `maap-py<5`